### PR TITLE
Changed locale in run_site.sh and edited README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ To build and run the website inside a docker container.
 docker run -it --rm -p 4567:4567 mesosphere/mesos-site
 ```
 
-This will start a container, download sources from SVN and Git, generate the website and make it available at http://localhost:4567.
+This will start a container, download sources from SVN and Git, generate the website and make it available.
+On linux, the site will be available at http://localhost:4567.
+On OSX, run `docker-machine ls` to find the IP address of your docker VM; the site will be available at that IP, port 4567.
 Any changes to the svn `/publish` directory (static content) will cause middleman to reload and regenerate the website, so you can just edit, save, refresh.
 When you are done with the webserver, hit Ctrl-C in the docker terminal to kill the middleman webserver and destroy/remove the container.
 

--- a/files/run_site.sh
+++ b/files/run_site.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-export LANG="en_US.UTF-7"
-export LANGUAGE="en_US.UTF-8"
-export LC_ALL="en_US.UTF-8"
+export LANG="C.UTF-8"
+export LANGUAGE="C.UTF-8"
+export LC_ALL="C.UTF-8"
 
 if [ -z $1 ]; then
   echo "Pulling website source from svn"


### PR DESCRIPTION
In the docker, the "en_US.UTF-8" locale is not available, which leads to the Rake command failing if it encounters any characters outside of the US-ASCII standard. The "C.UTF-8" locale is, however, available.

Also includes a change to the README giving proper instructions for finding the website's IP address on OSX.
